### PR TITLE
Stretch Auto Grid

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,9 @@ pageTitle: Changelog
 * [breaking] breaking change
 * [fix] Bugfix
 
+## Unreleased
+* [update] add `data-stretch` modifier to `auto-grid`
+
 ## 0.2.1
 * [fix] Renamed `styles.scss` to `_styles.scss` to prevent `src/style.css` from
   being generated in development mode.

--- a/docs/objects/5-auto-grid.md
+++ b/docs/objects/5-auto-grid.md
@@ -89,6 +89,44 @@ the `data-measure` attribute.
 </div>
 {% endcodeSample %}
 
+## Stretching the Grid
+By default every element in the grid will obey strictly to the grid. If you only
+have one box in a grid at a large viewport, this box will only occupy the first
+column, even if there are potentially more columns available. In many scenarios
+this is the desired default.
+
+However you might also need a grid from time to time where the elements stretch
+out to always fill the full width of a row. This can be achieved by adding the
+`data-stretch` modifier to your auto grid element.
+
+If a grid row is wider than the amount of available columns it will break into a
+new row thereby reverting to the default auto grid behavior.
+
+There is a good [in-depth article on CSS Grid column
+sizing](https://css-tricks.com/auto-sizing-columns-css-grid-auto-fill-vs-auto-fit/)
+over on CSS-Tricks.
+
+{% codeSample %}
+<div
+  class="o-auto-grid"
+  data-measure="narrow"
+  data-stretch
+>
+  <div class="o-box u-bg-white">
+    I am in a box
+  </div>
+  <div class="o-box u-bg-white">
+    I am in a box
+  </div>
+  <div class="o-box u-bg-white">
+    I am in a box
+  </div>
+  <div class="o-box u-bg-white">
+    I am in a box
+  </div>
+</div>
+{% endcodeSample %}
+
 ## Use Cases
 The auto grid is good when you have a bunch of equally important items that you
 want to place in a responsive grid without worrying about breakpoints.

--- a/src/objects/_auto-grid.object.scss
+++ b/src/objects/_auto-grid.object.scss
@@ -6,6 +6,10 @@
   grid-gap: var(--o-auto-grid--spacing);
   grid-template-columns: repeat(auto-fill, minmax(var(--o-auto-grid--min-width), 1fr));
 
+  &[data-stretch] {
+    grid-template-columns: repeat(auto-fit, minmax(var(--o-auto-grid--min-width), 1fr));
+  }
+
   @each $spacing-name, $spacing-value in $layout-spacing--variants {
     &[data-spacing='#{$spacing-name}'] {
       --o-auto-grid--spacing: var(--layout-spacing--#{$spacing-name});
@@ -18,3 +22,4 @@
     }
   }
 }
+


### PR DESCRIPTION
Adds the `[data-stretch]` modifier to the `auto-grid` allowing columns to stretch to take up any available space in the grid if there are less actual columns than columns in the CSS grid.